### PR TITLE
Accommodate for the Arduino's poor serial code

### DIFF
--- a/src/Board.php
+++ b/src/Board.php
@@ -428,6 +428,7 @@ namespace Carica\Firmata {
       $this->events()->on('response',Array($this,'recieveDataMaybeVersion'));
       $this->waitingForVersion = true;
       $this->versionRetriesMessageCount = 24;
+      $this->events()->once('reportversion', $callback);
       $this->stream()->write([self::REPORT_VERSION]);
     }
 


### PR DESCRIPTION
This patch enables retries for the report version command.

Effectively the device may not see the command or doesn't respond correctly.  This allows for retrying the command up to 5 times, which makes initialisation much more reliable.
